### PR TITLE
138 - Listing wrongly answered questions from the last three days

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -4,6 +4,9 @@ class Answer < ApplicationRecord
   has_rich_text :content
   has_many :quiz_questions, dependent: :destroy
 
+  scope :correct, -> { where(correct: true) }
+  scope :wrong, -> { where(correct: false) }
+
   def name
     content
   end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -6,6 +6,7 @@ class Answer < ApplicationRecord
 
   scope :correct, -> { where(correct: true) }
   scope :wrong, -> { where(correct: false) }
+  scope :recently_answered, -> { where("quiz_questions.updated_at > ?", 3.days.ago )}
 
   def name
     content

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   devise :invitable, :database_authenticatable, :recoverable, :rememberable, :validatable
 
   has_many :quizzes, dependent: :destroy
+  has_many :quiz_questions, through: :quizzes
+  has_many :answers, through: :quiz_questions
 
   scope :admin, -> { where(admin: true) }
 

--- a/app/views/course/dashboards/_answer.html.erb
+++ b/app/views/course/dashboards/_answer.html.erb
@@ -1,0 +1,13 @@
+ <li class="d-flex justify-content-left align-items-center mb-3 ml-3">
+  <div class="mr-3">
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#a51c30" class="bi bi-x-square" viewBox="0 0 16 16">
+      <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/>
+      <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
+    </svg>
+  </div>
+  <div>
+    <div>Section: <%= answer.quiz_questions.last.quiz.quizable.title %></div>
+    <div class="inline-trix-content">Question: <%= answer.quiz_questions.last.question.prompt %></div>
+    <div class="inline-trix-content">You answered: <%= answer.content %></div>
+  </div>
+</li>

--- a/app/views/course/dashboards/show.html.erb
+++ b/app/views/course/dashboards/show.html.erb
@@ -4,10 +4,8 @@
 <p>Here are your missed questions for the last three days. Spend some time reviewing them before retaking the quiz.</p>
 <div class="mb-3">
   <ol>
-    <% current_user.answers.wrong.each do |answer| %>
-      <% if answer.quiz_questions.last.created_at > 3.days.ago %>
+    <% current_user.answers.recently_answered.wrong.each do |answer| %>
         <li><%= answer.quiz_questions.last.question.prompt %></li>
-      <% end %>
     <% end %>
   </ul>
 </div>

--- a/app/views/course/dashboards/show.html.erb
+++ b/app/views/course/dashboards/show.html.erb
@@ -1,7 +1,7 @@
 <h1 class="mb-3">Welcome Back!</h1>
 
-<h2>Please Review</h2>
-<p>Here are your missed questions for the last three days.</p>
+<h2>Time For A Review</h2>
+<p>Here are your missed questions for the last three days. Spend some time reviewing them before retaking the quiz.</p>
 <div class="mb-3">
   <% current_user.answers.wrong.each do |answer| %>
   <% if answer.quiz_questions.last.created_at > 3.days.ago %>

--- a/app/views/course/dashboards/show.html.erb
+++ b/app/views/course/dashboards/show.html.erb
@@ -1,2 +1,13 @@
-<h1 class="mb-3">Hi, <%= current_user.email %></h1>
-<%= link_to "Learn", course_section_path(@section), class: "btn btn-primary" %>
+<h1 class="mb-3">Welcome Back!</h1>
+
+<h2>Please Review</h2>
+<p>Here are your missed questions for the last three days.</p>
+<div class="mb-3">
+  <% current_user.answers.wrong.each do |answer| %>
+  <% if answer.quiz_questions.last.created_at > 3.days.ago %>
+      <%= render "course/quiz_questions/card", quiz_question: answer.quiz_questions.last %>
+  <% end %>
+<% end %>
+</div>
+
+<%= link_to "Learn", course_section_path(@section), class: "btn btn-primary mb-3" %>

--- a/app/views/course/dashboards/show.html.erb
+++ b/app/views/course/dashboards/show.html.erb
@@ -3,11 +3,13 @@
 <h2>Time For A Review</h2>
 <p>Here are your missed questions for the last three days. Spend some time reviewing them before retaking the quiz.</p>
 <div class="mb-3">
-  <% current_user.answers.wrong.each do |answer| %>
-  <% if answer.quiz_questions.last.created_at > 3.days.ago %>
-      <%= render "course/quiz_questions/card", quiz_question: answer.quiz_questions.last %>
-  <% end %>
-<% end %>
+  <ol>
+    <% current_user.answers.wrong.each do |answer| %>
+      <% if answer.quiz_questions.last.created_at > 3.days.ago %>
+        <li><%= answer.quiz_questions.last.question.prompt %></li>
+      <% end %>
+    <% end %>
+  </ul>
 </div>
 
 <%= link_to "Learn", course_section_path(@section), class: "btn btn-primary mb-3" %>

--- a/app/views/course/dashboards/show.html.erb
+++ b/app/views/course/dashboards/show.html.erb
@@ -3,9 +3,9 @@
 <h2>Time For A Review</h2>
 <p>Here are your missed questions for the last three days. Spend some time reviewing them before retaking the quiz.</p>
 <div class="mb-3">
-  <ol>
-    <% current_user.answers.recently_answered.wrong.each do |answer| %>
-        <li><%= answer.quiz_questions.last.question.prompt %></li>
+  <ul style="list-style: none; padding: 0;">
+    <% current_user.answers.recently_answered.distinct.wrong.each do |answer| %>
+       <%= render "course/dashboards/answer", answer: answer %>
     <% end %>
   </ul>
 </div>


### PR DESCRIPTION
I think these changes accomplish what was required of this issue however I'd like to continue working with the styling to make the UI better.

What do you guys think about separating the wrong answers by the section they're associated with? We could make the sections collapsible similar to how the answer body is collapsible. I'm having trouble determining how to associate sections with answers, maybe you can give me a hint there @caioertai .

Thoughts??