### PR TITLE
removed truncate from question text on quiz report

### DIFF
--- a/app/views/course/quiz_questions/_card_header.html.erb
+++ b/app/views/course/quiz_questions/_card_header.html.erb
@@ -10,7 +10,7 @@
     <% else %>
       <span class="badge badge-danger mr-2">Wrong</span>
     <% end %>
-    <%= quiz_question.question.prompt.to_plain_text.truncate(60) %>
+    <%= quiz_question.question.prompt.to_plain_text %>
   </div>
 
   <div>


### PR DESCRIPTION
Closes #174 

Full question text now shows on the quiz report.