### PR TITLE
Reduce appeal of the left bar

### DIFF
--- a/app/assets/stylesheets/pages/_course.scss
+++ b/app/assets/stylesheets/pages/_course.scss
@@ -27,7 +27,8 @@ $course-font-size: 1.25rem;
 .course-sidebar {
   padding: 1.5rem 2rem;
   border-right: 1px solid darken($light-gray, 5%);
-  max-width: 32%;
+  max-width: 25%;
+  position: relative;
 
   li.active {
     list-style: disclosure-closed;
@@ -57,6 +58,26 @@ $course-font-size: 1.25rem;
   }
 
   h2 {
-    font-size: 1.5rem;
+    font-size: 1.25rem;
+  }
+
+  &:hover &-overlay {
+    display: none;
+  }
+
+  &-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: $gray;
+    opacity: 0.3;
+  }
+}
+
+@media screen and (max-width: 1100px) {
+  .course-sidebar {
+    max-width: 35%;
   }
 }

--- a/app/views/layouts/course.html.erb
+++ b/app/views/layouts/course.html.erb
@@ -15,6 +15,7 @@
     <div class="course-layout">
       <div class="course-sidebar">
         <%= render "course/chapters/menu", chapters: @chapters %>
+        <div class="course-sidebar-overlay"></div>
       </div>
       <div class="course-container"><%= yield %></div>
     </div>


### PR DESCRIPTION
closes #178 

narrowed the course navigation sidebar width to 25% on wider screens over 1100px. Created an overlay on top of the sidebar to shift focus away from it when not focused.

I think the overlay can look better, @caioertai let me know if you have any ideas, I'll run it by Sean/Matt as well.