### PR TITLE
Link to quiz report in Section#show

### DIFF
--- a/app/views/course/sections/show.html.erb
+++ b/app/views/course/sections/show.html.erb
@@ -1,6 +1,11 @@
 <div class="shadow-sm course-page">
   <h6><%= @section.chapter.title %></h6>
   <h1 class="mb-3"><%= @section.title %></h1>
+  <% if @quiz_session && @quiz_session.complete? %>
+  <% quiz_score = number_to_percentage(@quiz_session.correct_answers_ratio * 100, precision: 0) %>
+  <p>You scored <%= quiz_score %> on this section's quiz.</p>
+  <%= link_to "See Quiz Report", course_section_path(@section, anchor: "quiz"), class: "btn btn-primary" %>
+  <% end %>
   <div class="course-content"><%= @section.content %></div>
 </div>
 <% if @quiz_session.present? %>


### PR DESCRIPTION
Closes #173 

added a link at the top of section#show that links to the quiz report if it exists.
I decided not to include a progress bar - the progress bars we have currently show chapter completion or course completion %, not quiz scores. So just to stay consistent with that I left it out.