### PR TITLE
Performance Graph

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development do
   gem "web-console", ">= 3.3.0"
 
   gem "dotenv-rails"
+  gem "faker", require: false
 
   gem "rubocop"
   gem "rubocop-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.9.0)
+    faker (2.17.0)
+      i18n (>= 1.6, < 2)
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -349,6 +351,7 @@ DEPENDENCIES
   devise
   devise_invitable (~> 2.0.0)
   dotenv-rails
+  faker
   httparty
   jbuilder (~> 2.7)
   listen (~> 3.2)

--- a/app/controllers/course/dashboards_controller.rb
+++ b/app/controllers/course/dashboards_controller.rb
@@ -3,6 +3,5 @@ class Course::DashboardsController < Course::ApplicationController
     authorize [:course, :dashboard]
 
     @section = policy_scope(Chapter).first.sections.first
-    @performance = QuizQuestion::PerformanceQuery.new(current_user.quiz_questions)
   end
 end

--- a/app/controllers/course/dashboards_controller.rb
+++ b/app/controllers/course/dashboards_controller.rb
@@ -3,5 +3,6 @@ class Course::DashboardsController < Course::ApplicationController
     authorize [:course, :dashboard]
 
     @section = policy_scope(Chapter).first.sections.first
+    @performance = QuizQuestion::PerformanceQuery.new(current_user.quiz_questions)
   end
 end

--- a/app/javascript/controllers/charts_controller.js
+++ b/app/javascript/controllers/charts_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  connect() {
+    debugger
+  }
+}

--- a/app/javascript/controllers/charts_controller.js
+++ b/app/javascript/controllers/charts_controller.js
@@ -3,16 +3,6 @@ import {Highcharts} from 'highcharts-more-node'
 
 export default class extends Controller {
   connect() {
-    const categories = [
-      "Bar0",
-      "Bar45",
-      "Bar90",
-      "Bar135",
-      "Bar180",
-      "Bar225",
-      "Bar270",
-      "Bar315",
-    ]
     Highcharts.chart(this.element, JSON.parse(this.element.dataset.params))
   }
 }

--- a/app/javascript/controllers/charts_controller.js
+++ b/app/javascript/controllers/charts_controller.js
@@ -3,55 +3,16 @@ import {Highcharts} from 'highcharts-more-node'
 
 export default class extends Controller {
   connect() {
-    Highcharts.chart(this.element, {
-      chart: {
-        polar: true
-      },
-      title: {
-        text: 'Highcharts Polar Chart'
-      },
-      subtitle: {
-        text: 'Also known as Radar Chart'
-      },
-      pane: {
-        startAngle: 0,
-        endAngle: 360
-      },
-      xAxis: {
-        tickInterval: 45,
-        min: 0,
-        max: 360,
-        labels: {
-          format: '{value}°'
-        }
-      },
-      yAxis: {
-        min: 0
-      },
-      plotOptions: {
-        series: {
-          pointStart: 0,
-          pointInterval: 45
-        },
-        column: {
-          pointPadding: 0,
-          groupPadding: 0
-        }
-      },
-      series: [{
-        type: 'column',
-        name: 'Column',
-        data: [8, 7, 6, 5, 4, 3, 2, 1],
-        pointPlacement: 'between'
-      }, {
-        type: 'line',
-        name: 'Line',
-        data: [1, 2, 3, 4, 5, 6, 7, 8]
-      }, {
-        type: 'area',
-        name: 'Area',
-        data: [1, 8, 2, 7, 3, 6, 4, 5]
-      }]
-    })
+    const categories = [
+      "Bar0",
+      "Bar45",
+      "Bar90",
+      "Bar135",
+      "Bar180",
+      "Bar225",
+      "Bar270",
+      "Bar315",
+    ]
+    Highcharts.chart(this.element, JSON.parse(this.element.dataset.params))
   }
 }

--- a/app/javascript/controllers/charts_controller.js
+++ b/app/javascript/controllers/charts_controller.js
@@ -1,7 +1,57 @@
 import { Controller } from "stimulus"
+import {Highcharts} from 'highcharts-more-node'
 
 export default class extends Controller {
   connect() {
-    debugger
+    Highcharts.chart(this.element, {
+      chart: {
+        polar: true
+      },
+      title: {
+        text: 'Highcharts Polar Chart'
+      },
+      subtitle: {
+        text: 'Also known as Radar Chart'
+      },
+      pane: {
+        startAngle: 0,
+        endAngle: 360
+      },
+      xAxis: {
+        tickInterval: 45,
+        min: 0,
+        max: 360,
+        labels: {
+          format: '{value}°'
+        }
+      },
+      yAxis: {
+        min: 0
+      },
+      plotOptions: {
+        series: {
+          pointStart: 0,
+          pointInterval: 45
+        },
+        column: {
+          pointPadding: 0,
+          groupPadding: 0
+        }
+      },
+      series: [{
+        type: 'column',
+        name: 'Column',
+        data: [8, 7, 6, 5, 4, 3, 2, 1],
+        pointPlacement: 'between'
+      }, {
+        type: 'line',
+        name: 'Line',
+        data: [1, 2, 3, 4, 5, 6, 7, 8]
+      }, {
+        type: 'area',
+        name: 'Area',
+        data: [1, 8, 2, 7, 3, 6, 4, 5]
+      }]
+    })
   }
 }

--- a/app/models/charts/skills.rb
+++ b/app/models/charts/skills.rb
@@ -1,0 +1,65 @@
+class Charts::Skills
+  def initialize
+
+  end
+
+  def tag_slugs
+    @tag_slugs ||= Tag.pluck(:slug)
+  end
+
+  def tags_count
+    tag_slugs.count
+  end
+
+  def categories
+    tag_slugs.map.with_index { |category, index| [interval * index, category] }.to_h
+  end
+
+  def interval
+    360 / tags_count
+  end
+
+  def params
+    {
+      chart: {
+        polar: true
+      },
+      title: {
+        text: 'Highcharts Polar Chart'
+      },
+      subtitle: {
+        text: 'Also known as Radar Chart'
+      },
+      pane: {
+        startAngle: 0,
+        endAngle: 360
+      },
+      xAxis: {
+        tickInterval: 45,
+        min: 0,
+        max: 360,
+        labels: {
+          format: '{value}°'
+        },
+        categories: categories
+      },
+      yAxis: {
+        min: 0
+      },
+      plotOptions: {
+        series: {
+          pointStart: 0,
+          pointInterval: 45
+        },
+        column: {
+          pointPadding: 0,
+          groupPadding: 0
+        }
+      },
+      series: [{
+        type: 'area',
+        data: [8, 7, 6, 5, 4, 3, 2, 1],
+      }]
+    }
+  end
+end

--- a/app/models/charts/skills.rb
+++ b/app/models/charts/skills.rb
@@ -16,7 +16,11 @@ class Charts::Skills
   end
 
   def interval
-    360 / tags_count
+    360 / (tags_count + 1)
+  end
+
+  def full_angle
+    interval * tags_count
   end
 
   def params
@@ -25,40 +29,31 @@ class Charts::Skills
         polar: true
       },
       title: {
-        text: 'Highcharts Polar Chart'
+        text: "Skills Performance"
       },
       subtitle: {
-        text: 'Also known as Radar Chart'
-      },
-      pane: {
-        startAngle: 0,
-        endAngle: 360
+        text: "Based on you last quizes"
       },
       xAxis: {
-        tickInterval: 45,
-        min: 0,
-        max: 360,
-        labels: {
-          format: '{value}°'
-        },
-        categories: categories
+        tickInterval: interval,
+        categories: categories,
+        max: full_angle,
       },
       yAxis: {
-        min: 0
+        max: 100,
+        labels: {
+          format: '{value}%'
+        }
       },
       plotOptions: {
         series: {
-          pointStart: 0,
-          pointInterval: 45
-        },
-        column: {
-          pointPadding: 0,
-          groupPadding: 0
+          pointInterval: interval
         }
       },
       series: [{
-        type: 'area',
-        data: [8, 7, 6, 5, 4, 3, 2, 1],
+        type: "area",
+        name: "",
+        data: Array.new(tags_count) { rand(7..10) * rand(7..10) },
       }]
     }
   end

--- a/app/models/charts/skills.rb
+++ b/app/models/charts/skills.rb
@@ -28,6 +28,7 @@ class Charts::Skills
       chart: {
         polar: true
       },
+      legend: false,
       title: {
         text: "Skills Performance"
       },
@@ -52,8 +53,8 @@ class Charts::Skills
       },
       series: [{
         type: "area",
-        name: "",
         data: Array.new(tags_count) { rand(7..10) * rand(7..10) },
+        color: "rgb(200, 100, 100)"
       }]
     }
   end

--- a/app/models/charts/tags.rb
+++ b/app/models/charts/tags.rb
@@ -36,12 +36,8 @@ class Charts::Tags
         backgroundColor: "transparent"
       },
       legend: false,
-      title: {
-        text: "Skills Performance"
-      },
-      subtitle: {
-        text: "Based on your quiz answers"
-      },
+      title: { text: false },
+      subtitle: { text: false },
       xAxis: {
         tickInterval: interval,
         categories: categories,

--- a/app/models/charts/tags.rb
+++ b/app/models/charts/tags.rb
@@ -39,7 +39,7 @@ class Charts::Tags
         text: "Skills Performance"
       },
       subtitle: {
-        text: "Based on you last quizes"
+        text: "Based on your quiz answers"
       },
       xAxis: {
         tickInterval: interval,

--- a/app/models/charts/tags.rb
+++ b/app/models/charts/tags.rb
@@ -32,7 +32,8 @@ class Charts::Tags
   def params
     {
       chart: {
-        polar: true
+        polar: true,
+        backgroundColor: "transparent"
       },
       legend: false,
       title: {

--- a/app/models/charts/tags.rb
+++ b/app/models/charts/tags.rb
@@ -1,10 +1,12 @@
 class Charts::Tags
-  def initialize(tags)
-    @tags = tags
+  attr_reader :tags_performances
+
+  def initialize(tags_performances)
+    @tags_performances = tags_performances
   end
 
   def tag_slugs
-    @tag_slugs ||= Tag.pluck(:slug)
+    tags_performances.map(&:slug)
   end
 
   def tags_count
@@ -57,7 +59,7 @@ class Charts::Tags
       },
       series: [{
         type: "area",
-        data: Array.new(tags_count) { rand(7..10) * rand(7..10) },
+        data: tags_performances.map { |performance| performance.value * 100 },
         color: "rgb(200, 100, 100)"
       }]
     }

--- a/app/models/charts/tags.rb
+++ b/app/models/charts/tags.rb
@@ -46,6 +46,10 @@ class Charts::Tags
         categories: categories,
         max: full_angle,
       },
+      tooltip: {
+        valueDecimals: 0,
+        valueSuffix: "%",
+      },
       yAxis: {
         max: 100,
         labels: {

--- a/app/models/charts/tags.rb
+++ b/app/models/charts/tags.rb
@@ -1,6 +1,6 @@
-class Charts::Skills
-  def initialize
-
+class Charts::Tags
+  def initialize(tags)
+    @tags = tags
   end
 
   def tag_slugs
@@ -21,6 +21,10 @@ class Charts::Skills
 
   def full_angle
     interval * tags_count
+  end
+
+  def to_json
+    params.to_json
   end
 
   def params

--- a/app/models/charts/tags.rb
+++ b/app/models/charts/tags.rb
@@ -63,6 +63,7 @@ class Charts::Tags
       },
       series: [{
         type: "area",
+        name: "Performance",
         data: tags_performances.map { |performance| performance.value * 100 },
         color: "rgb(200, 100, 100)"
       }]

--- a/app/models/concerns/quizable.rb
+++ b/app/models/concerns/quizable.rb
@@ -5,5 +5,7 @@ module Quizable
     has_many :quizzes, as: :quizable, dependent: :destroy
     has_many :quizable_questions, as: :quizable, dependent: :destroy
     has_many :questions, through: :quizable_questions
+
+    scope :with_questions, -> {joins(:questions).distinct}
   end
 end

--- a/app/models/quiz_question/performance_query.rb
+++ b/app/models/quiz_question/performance_query.rb
@@ -30,7 +30,7 @@ class QuizQuestion::PerformanceQuery
   def correct_count_query
     <<~SQL
       SELECT COUNT(*)
-      FROM quiz_questions
+      FROM (#{@quiz_questions.to_sql}) quiz_questions
         INNER JOIN questions ON questions.id = quiz_questions.question_id
         INNER JOIN taggings ON taggings.taggable_type = 'Question' AND taggings.taggable_id = questions.id
         INNER JOIN answers ON answers.id = quiz_questions.answer_id

--- a/app/models/quiz_question/performance_query.rb
+++ b/app/models/quiz_question/performance_query.rb
@@ -6,7 +6,7 @@ class QuizQuestion::PerformanceQuery
   end
 
   def tags
-    @tags ||= data_attributes.map {|attrs| Tag::Performance.new(attrs)}.force
+    @tags ||= (data_attributes.map {|attrs| Tag::Performance.new(attrs)}.force + missing_tags)
   end
 
   def charts
@@ -16,6 +16,10 @@ class QuizQuestion::PerformanceQuery
   end
 
   private
+
+  def missing_tags
+    Tag.where.not(id: Tag.joins(:questions).where(questions: {quiz_questions: @quiz_questions}).distinct).pluck(:id, :slug).map {|id, slug| Tag::Performance.new(slug: slug, id: id)}
+  end
 
   def data_attributes
     total_data.lazy.map {|data| data.attributes.merge(correct_count: correct_data[data.id]) }

--- a/app/models/quiz_question/performance_query.rb
+++ b/app/models/quiz_question/performance_query.rb
@@ -5,15 +5,11 @@ class QuizQuestion::PerformanceQuery
     @quiz_questions = quiz_questions
   end
 
-  def tags_attributes
+  def result
     present_tags_attributes + missing_tags_attributes
   end
 
-  def charts
-    OpenStruct.new(
-      tags: Charts::Tags.new(tags)
-    )
-  end
+  private
 
   def missing_tags
     Tag.where.not(id: Tag.joins(:questions).where(questions: {quiz_questions: @quiz_questions}).distinct)

--- a/app/models/quiz_question/performance_query.rb
+++ b/app/models/quiz_question/performance_query.rb
@@ -5,8 +5,8 @@ class QuizQuestion::PerformanceQuery
     @quiz_questions = quiz_questions
   end
 
-  def tags
-    @tags ||= (data_attributes.map {|attrs| Tag::Performance.new(attrs)}.force + missing_tags)
+  def tags_attributes
+    present_tags_attributes + missing_tags_attributes
   end
 
   def charts
@@ -15,29 +15,39 @@ class QuizQuestion::PerformanceQuery
     )
   end
 
-  private
-
   def missing_tags
-    Tag.where.not(id: Tag.joins(:questions).where(questions: {quiz_questions: @quiz_questions}).distinct).pluck(:id, :slug).map {|id, slug| Tag::Performance.new(slug: slug, id: id)}
+    Tag.where.not(id: Tag.joins(:questions).where(questions: {quiz_questions: @quiz_questions}).distinct)
   end
 
-  def data_attributes
-    total_data.lazy.map {|data| data.attributes.merge(correct_count: correct_data[data.id]) }
+  def missing_tags_attributes
+    missing_tags.select(:id, :slug, "0 AS correct_count, 0 AS total_count").as_json
+  end
+
+  def present_tags_attributes
+    data.as_json
   end
 
   def relation
     @relation ||= @quiz_questions.joins(:tags, :answer).group("tags.id")
   end
 
-  def correct_data
-    @correct_data ||= relation.where(answers: {correct: true}).count
+  def correct_count_query
+    <<~SQL
+      SELECT COUNT(*)
+      FROM quiz_questions
+        INNER JOIN questions ON questions.id = quiz_questions.question_id
+        INNER JOIN taggings ON taggings.taggable_type = 'Question' AND taggings.taggable_id = questions.id
+        INNER JOIN answers ON answers.id = quiz_questions.answer_id
+      WHERE answers.correct = true AND tags.id = taggings.tag_id
+    SQL
   end
 
-  def total_data
-    @total_data ||= relation.select(
+  def data
+    @data ||= relation.select(
       "tags.id",
       "tags.slug",
       "count(quiz_questions.id) AS total_count",
+      "(#{correct_count_query}) AS correct_count"
     )
   end
 end

--- a/app/models/quiz_question/performance_query.rb
+++ b/app/models/quiz_question/performance_query.rb
@@ -6,20 +6,12 @@ class QuizQuestion::PerformanceQuery
   end
 
   def result
-    present_tags_attributes + missing_tags_attributes
+    performances_attributes
   end
 
   private
 
-  def missing_tags
-    Tag.where.not(id: Tag.joins(:questions).where(questions: {quiz_questions: @quiz_questions}).distinct)
-  end
-
-  def missing_tags_attributes
-    missing_tags.select(:id, :slug, "0 AS correct_count, 0 AS total_count").as_json
-  end
-
-  def present_tags_attributes
+  def performances_attributes
     data.as_json
   end
 

--- a/app/models/quiz_question/performance_query.rb
+++ b/app/models/quiz_question/performance_query.rb
@@ -9,6 +9,12 @@ class QuizQuestion::PerformanceQuery
     @tags ||= data_attributes.map {|attrs| Tag::Performance.new(attrs)}.force
   end
 
+  def charts
+    OpenStruct.new(
+      tags: Charts::Tags.new(tags)
+    )
+  end
+
   private
 
   def data_attributes

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,6 +1,7 @@
 class Tag < ApplicationRecord
   has_many :taggings, dependent: :destroy
   has_many :questions, through: :taggings, source: :taggable, source_type: "Question"
+  has_many :quiz_questions, through: :questions
 
   validates :slug, uniqueness: true, presence: true
 

--- a/app/models/tag/performance.rb
+++ b/app/models/tag/performance.rb
@@ -7,6 +7,10 @@ class Tag::Performance
   end
 
   def value
-    Rational(correct_count.to_i, total_count.to_i).to_f
+    Rational(correct_count.to_i, denominator).to_f
+  end
+
+  def denominator
+    correct_count.to_i.zero? ? 1 : total_count.to_i
   end
 end

--- a/app/models/tag/performance.rb
+++ b/app/models/tag/performance.rb
@@ -3,12 +3,16 @@ class Tag::Performance
   include ActiveModel::Model
   attr_accessor :id, :slug, :total_count, :correct_count
 
-  def object
-    @object ||= Tag.find(id)
+  def tag
+    @tag ||= Tag.find(id)
   end
 
   def value
     Rational(correct_count.to_i, denominator).to_f
+  end
+
+  def good?
+    value > 0.7
   end
 
   def denominator

--- a/app/models/tag/performance.rb
+++ b/app/models/tag/performance.rb
@@ -1,4 +1,5 @@
 class Tag::Performance
+  include Comparable
   include ActiveModel::Model
   attr_accessor :id, :slug, :total_count, :correct_count
 
@@ -12,5 +13,9 @@ class Tag::Performance
 
   def denominator
     correct_count.to_i.zero? ? 1 : total_count.to_i
+  end
+
+  def <=>(other)
+    value <=> other.value
   end
 end

--- a/app/models/tag/performance_collection.rb
+++ b/app/models/tag/performance_collection.rb
@@ -1,0 +1,18 @@
+class Tag::PerformanceCollection
+  include Enumerable
+
+  attr_reader :performances
+  def initialize(tag_performances_attributes)
+    @performances = tag_performances_attributes.map {|attrs|
+      Tag::Performance.new(attrs)
+    }
+  end
+
+  def each(&block)
+    @performances.each(&block)
+  end
+
+  def chart
+    Charts::Tags.new(performances)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   has_many :completed_sections, -> { distinct }, through: :completed_quizzes, source: :quizable, source_type: "Section"
   has_many :quiz_questions, through: :quizzes
   has_many :answers, through: :quiz_questions
+  has_many :tags, ->{distinct}, through: :quiz_questions
 
   after_save :enqueue_ping_lsac if :prep_plus_changed?
 

--- a/app/models/user/course_status.rb
+++ b/app/models/user/course_status.rb
@@ -5,6 +5,12 @@ class User::CourseStatus
     @user = user
   end
 
+  def performance
+    OpenStruct.new(
+      tags: Tag::PerformanceCollection.new(performance_data)
+    )
+  end
+
   def completion_rate
     completed_sections.count.fdiv(section_statuses.size)
   end
@@ -27,5 +33,11 @@ class User::CourseStatus
 
   def section_statuses_for(chapter)
     section_statuses.select { |section_status| section_status.section.chapter == chapter }
+  end
+
+  private
+
+  def performance_data
+    @performance_data ||= QuizQuestion::PerformanceQuery.new(user.quiz_questions).result
   end
 end

--- a/app/models/user/course_status.rb
+++ b/app/models/user/course_status.rb
@@ -6,9 +6,7 @@ class User::CourseStatus
   end
 
   def performance
-    OpenStruct.new(
-      tags: Tag::PerformanceCollection.new(performance_data)
-    )
+    Performance.new(course_status: self)
   end
 
   def completion_rate
@@ -33,11 +31,5 @@ class User::CourseStatus
 
   def section_statuses_for(chapter)
     section_statuses.select { |section_status| section_status.section.chapter == chapter }
-  end
-
-  private
-
-  def performance_data
-    @performance_data ||= QuizQuestion::PerformanceQuery.new(user.quiz_questions).result
   end
 end

--- a/app/models/user/course_status/performance.rb
+++ b/app/models/user/course_status/performance.rb
@@ -1,0 +1,20 @@
+class User::CourseStatus::Performance
+  include ActiveModel::Model
+
+  attr_accessor :course_status
+
+  def tags
+    @tags ||= Tag::PerformanceCollection.new(performance_data)
+  end
+
+  def missing_tags
+    @missing_tags ||= Tag.count - user.tags.count
+  end
+
+  private
+
+  def performance_data
+    @performance_data ||= QuizQuestion::PerformanceQuery.new(course_status.user.quiz_questions).result
+  end
+end
+

--- a/app/models/user/course_status/performance.rb
+++ b/app/models/user/course_status/performance.rb
@@ -7,8 +7,8 @@ class User::CourseStatus::Performance
     @tags ||= Tag::PerformanceCollection.new(performance_data)
   end
 
-  def missing_tags
-    @missing_tags ||= Tag.count - user.tags.count
+  def missing_tags_count
+    @missing_tags_count ||= Tag.count - course_status.user.tags.count
   end
 
   private

--- a/app/views/course/dashboards/show.html.erb
+++ b/app/views/course/dashboards/show.html.erb
@@ -15,7 +15,19 @@
   </li>
 </ul>
 
-<div data-controller="charts"></div>
+<div data-controller="charts" data-params="<%= Charts::Skills.new.params.to_json %>">
+  <figure class="highcharts-figure">
+      <div data-charts-target="graph"></div>
+      <p class="highcharts-description">
+        The wind rose chart is often used to visualize wind patterns. In this
+        example, the chart shows the wind speed distribution. This is
+        achieved with a polar stacked column chart.
+      </p>
+  </figure>
+</div>
+
+
+
 
 <%= render "course/review" %>
 <%= render "course/suggested" %>

--- a/app/views/course/dashboards/show.html.erb
+++ b/app/views/course/dashboards/show.html.erb
@@ -15,7 +15,7 @@
   </li>
 </ul>
 
-<div data-controller="charts" data-params="<%= Charts::Skills.new.params.to_json %>">
+<div data-controller="charts" data-params="<%= @performance.charts.tags.to_json %>">
   <figure class="highcharts-figure">
       <div data-charts-target="graph"></div>
       <p class="highcharts-description">

--- a/app/views/course/dashboards/show.html.erb
+++ b/app/views/course/dashboards/show.html.erb
@@ -17,4 +17,3 @@
 
 <%= render "course/review" %>
 <%= render "course/suggested" %>
-</div>

--- a/app/views/course/dashboards/show.html.erb
+++ b/app/views/course/dashboards/show.html.erb
@@ -15,5 +15,7 @@
   </li>
 </ul>
 
+<div data-controller="charts"></div>
+
 <%= render "course/review" %>
 <%= render "course/suggested" %>

--- a/app/views/course/dashboards/show.html.erb
+++ b/app/views/course/dashboards/show.html.erb
@@ -15,7 +15,7 @@
   </li>
 </ul>
 
-<div data-controller="charts" data-params="<%= @performance.charts.tags.to_json %>">
+<div data-controller="charts" data-params="<%= current_user.course_status.performance.tags.chart.to_json %>">
   <figure class="highcharts-figure">
       <div data-charts-target="graph"></div>
       <p class="highcharts-description">

--- a/app/views/course/dashboards/show.html.erb
+++ b/app/views/course/dashboards/show.html.erb
@@ -15,19 +15,7 @@
   </li>
 </ul>
 
-<div data-controller="charts" data-params="<%= current_user.course_status.performance.tags.chart.to_json %>">
-  <figure class="highcharts-figure">
-      <div data-charts-target="graph"></div>
-      <p class="highcharts-description">
-        The wind rose chart is often used to visualize wind patterns. In this
-        example, the chart shows the wind speed distribution. This is
-        achieved with a polar stacked column chart.
-      </p>
-  </figure>
-</div>
-
-
-
+<%= render current_user.course_status.performance %>
 
 <%= render "course/review" %>
 <%= render "course/suggested" %>

--- a/app/views/course/tags/_tag.html.erb
+++ b/app/views/course/tags/_tag.html.erb
@@ -1,1 +1,3 @@
-<span class="badge badge-secondary"><%= tag.slug %></span>
+<% badge_class = local_assigns[:class] || "secondary" %>
+
+<span class="badge badge-<%= badge_class %>"><%= tag.slug %></span>

--- a/app/views/course/tags/_tag.html.erb
+++ b/app/views/course/tags/_tag.html.erb
@@ -1,0 +1,1 @@
+<span class="badge badge-secondary"><%= tag.slug %></span>

--- a/app/views/course/tags/performances/_best.html.erb
+++ b/app/views/course/tags/performances/_best.html.erb
@@ -1,0 +1,7 @@
+You scored <%= number_to_percentage(best.value * 100, precision: 0) %>
+on questions relating to <%= render best.tag, class: best.good? ? "success" : "info" %>.
+<% if best.good? %>
+  <strong>Congratulations on your performance!</strong>
+<% else %>
+  <span>That's not yet great, but <strong>we can improve it</strong> with some dedication.</span>
+<% end %>

--- a/app/views/course/tags/performances/_worst.html.erb
+++ b/app/views/course/tags/performances/_worst.html.erb
@@ -1,0 +1,11 @@
+We recommend you
+<span class="text-danger">work more on your</span>
+<%= render worst.tag, class: "danger" %>.
+<% if false && best_performance.good? %>
+  Hey, it's still a great result!
+  <strong>But we can get it even better!</strong>
+<% else %>
+  Don't feel down,
+  <strong>we can improve it</strong>
+  with some dedication.
+<% end %>

--- a/app/views/course/tags/performances/_worst.html.erb
+++ b/app/views/course/tags/performances/_worst.html.erb
@@ -1,7 +1,7 @@
 We recommend you
 <span class="text-danger">work more on your</span>
 <%= render worst.tag, class: "danger" %>.
-<% if false && best_performance.good? %>
+<% if worst.good? %>
   Hey, it's still a great result!
   <strong>But we can get it even better!</strong>
 <% else %>

--- a/app/views/course/user/course_status/performances/_performance.html.erb
+++ b/app/views/course/user/course_status/performances/_performance.html.erb
@@ -1,2 +1,8 @@
+<h2 class="h4">General Performance</h2>
 <div data-controller="charts" data-params="<%= performance.tags.chart.to_json %>"></div>
-<%= performance.tags.min.slug %>
+<hr>
+
+<p>
+  <%= render object: performance.tags.max, partial: "course/tags/performances/best" %>
+  <%= render object: performance.tags.min, partial: "course/tags/performances/worst" %>
+</p>

--- a/app/views/course/user/course_status/performances/_performance.html.erb
+++ b/app/views/course/user/course_status/performances/_performance.html.erb
@@ -1,0 +1,11 @@
+<div data-controller="charts" data-params="<%= performance.tags.chart.to_json %>">
+  <figure class="highcharts-figure">
+      <div data-charts-target="graph"></div>
+      <p class="highcharts-description">
+        The wind rose chart is often used to visualize wind patterns. In this
+        example, the chart shows the wind speed distribution. This is
+        achieved with a polar stacked column chart.
+      </p>
+  </figure>
+</div>
+<%= performance.tags.min.slug %>

--- a/app/views/course/user/course_status/performances/_performance.html.erb
+++ b/app/views/course/user/course_status/performances/_performance.html.erb
@@ -1,11 +1,2 @@
-<div data-controller="charts" data-params="<%= performance.tags.chart.to_json %>">
-  <figure class="highcharts-figure">
-      <div data-charts-target="graph"></div>
-      <p class="highcharts-description">
-        The wind rose chart is often used to visualize wind patterns. In this
-        example, the chart shows the wind speed distribution. This is
-        achieved with a polar stacked column chart.
-      </p>
-  </figure>
-</div>
+<div data-controller="charts" data-params="<%= performance.tags.chart.to_json %>"></div>
 <%= performance.tags.min.slug %>

--- a/app/views/course/user/course_status/performances/_performance.html.erb
+++ b/app/views/course/user/course_status/performances/_performance.html.erb
@@ -1,6 +1,7 @@
-<h2 class="h4">General Performance</h2>
-<div data-controller="charts" data-params="<%= performance.tags.chart.to_json %>"></div>
+<h2 class="h3">General Performance</h2>
 <hr>
+<h3 class="h4">Skills performance <small class="h6">Based on your quiz answers</small></h3>
+<div data-controller="charts" data-params="<%= performance.tags.chart.to_json %>"></div>
 
 <p>
   <%= render object: performance.tags.max, partial: "course/tags/performances/best" %>

--- a/app/views/course/user/course_status/performances/_performance.html.erb
+++ b/app/views/course/user/course_status/performances/_performance.html.erb
@@ -7,3 +7,13 @@
   <%= render object: performance.tags.max, partial: "course/tags/performances/best" %>
   <%= render object: performance.tags.min, partial: "course/tags/performances/worst" %>
 </p>
+
+<% performance.missing_tags_count.tap do |tag_count| %>
+  <% if tag_count.positive? %>
+    <p>
+      There <%= tag_count.eql?(1) ? "is" : "are" %> still
+      <strong><%= pluralize(tag_count, "tag") %> you haven't found in our quizzes</strong>.
+      Keep going through the sections and you'll have them all in no time!
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/questions/_tags.html.erb
+++ b/app/views/questions/_tags.html.erb
@@ -1,6 +1,4 @@
-<% question.tags.each do |tag| %>
-  <span class="badge badge-secondary"><%= tag.slug %></span>
-<% end %>
+<%= render question.tags %>
 
 <% if question.tags.empty? %>
   <div class="badge badge-danger">No Tags</div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,13 +1,13 @@
 require "faker"
 
 puts "Creating users..."
-user_params = [
-  { email: "user@user.com",   password: "123456", paying: true,  admin: false },
-  { email: "free@user.com",   password: "123456", paying: false, admin: true },
-  { email: "paying@user.com", password: "123456", paying: true,  admin: false },
-  { email: "admin@user.com",  password: "123456", paying: true,  admin: true },
-]
-User.create!(user_params)
+users = {
+  free:     User.create!(email: "free@user.com",     password: "123456", paying: false, admin: true,  prep_plus: false),
+  user:     User.create!(email: "user@user.com",     password: "123456", paying: true,  admin: false, prep_plus: true ),
+  paying:   User.create!(email: "paying@user.com",   password: "123456", paying: true,  admin: false, prep_plus: true ),
+  admin:    User.create!(email: "admin@user.com",    password: "123456", paying: true,  admin: true,  prep_plus: true ),
+  frequent: User.create!(email: "frequent@user.com", password: "123456", paying: true,  admin: true,  prep_plus: true ),
+}
 
 puts "Creating premium tags..."
 Tag.create!(slug: "lsat-premium", premium: true)
@@ -46,4 +46,29 @@ tags = 8.times.map do
 end
 
 puts "Assigning extra tags..."
-Question.find_each { |question| question.tags << tags.sample(3) }
+Question.find_each { |question| question.tags << tags.sample(2) }
+
+puts "Creating intro article..."
+Article.create!(title: "Intro", intro: true)
+
+
+
+puts "Anwering questions for frequent user..."
+Section.with_questions.each do |section|
+  quiz = QuizBuilder.new(quizable: section, user: users[:frequent]).build_and_save
+  quiz.quiz_questions.includes(:possible_answers).each do |qq|
+    variance_constant = 5
+
+    # This generates a proficiency value foro the user in the given tag based on
+    # the highest tag index
+    tag_proficiency = tags.map {|tag| tags.index(tag) }.max
+
+    # The following generates "tag_proficiency" times more correct than wrong answers
+    generated_answers = (
+      Array.new(variance_constant * tag_proficiency) {qq.possible_answers.correct} +
+      Array.new(variance_constant)                   {qq.possible_answers.wrong}
+    ).flatten
+
+    qq.update(answer: generated_answers.sample)
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+require "faker"
+
 puts "Creating users..."
 user_params = [
   { email: "user@user.com",   password: "123456", paying: true,  admin: false },
@@ -37,3 +39,11 @@ Product.create!(
   price: 6295,
   full_price: 8550,
 )
+
+puts "Creating extra random seeds..."
+tags = 8.times.map do
+  Tag.create!(slug: Faker::Games::DnD.unique.language.parameterize)
+end
+
+puts "Assigning extra tags..."
+Question.find_each { |question| question.tags << tags.sample(3) }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@rails/webpacker": "4.2.2",
     "bootstrap": "^4.5.2",
     "choices.js": "^9.0.1",
-    "highcharts": "^9.0.1",
+    "highcharts-more-node": "^5.0.13",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
     "stimulus": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@rails/webpacker": "4.2.2",
     "bootstrap": "^4.5.2",
     "choices.js": "^9.0.1",
+    "highcharts": "^9.0.1",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
     "stimulus": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3429,6 +3429,11 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+highcharts@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.0.1.tgz#49ec994a7897a96fc3e0880f49a0eca34adff6a2"
+  integrity sha512-0UmcCz2RmFuqfT/Igu3h5sGnkeSqqZwfuYrTzJ/htptmJAo5SSxH62NFcTjVRk+3WstoBJmoXR0v5FVGQUzK5A==
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3429,10 +3429,17 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highcharts@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.0.1.tgz#49ec994a7897a96fc3e0880f49a0eca34adff6a2"
-  integrity sha512-0UmcCz2RmFuqfT/Igu3h5sGnkeSqqZwfuYrTzJ/htptmJAo5SSxH62NFcTjVRk+3WstoBJmoXR0v5FVGQUzK5A==
+highcharts-more-node@^5.0.13:
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/highcharts-more-node/-/highcharts-more-node-5.0.13.tgz#736e89cd5228ac9f32fb90924a4765bfc4072694"
+  integrity sha512-+dKD7yycA5H/SpVK9yThvsCTJgwba/6o+U/htWyxC7uKQ+IuMxJStqohRXE0hGjLNrAnbFG6mm7YA/uEuei81Q==
+  dependencies:
+    highcharts "^5.0.12"
+
+highcharts@^5.0.12:
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-5.0.15.tgz#a9af11538a85b85f300e66f7a0e048a7ef8ab381"
+  integrity sha512-+LTe57ntLyWgkjsHzLmvRspM3FVKtds7iDswOTwuTAmZD3FtG1I/DqHiVSRjX92RQmQMZ1M7dcoRb7T648m1xA==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Changes:
- Adds Highcharts
- Adds `Charts::Tags` as an adapter for `Highcharts` params. It's a possible template for other future charts.
- Updates seeds to include some randomized questions for a `frequent@user.com` that has many quizzes answered. 
- Add best tag, worst tag, and missing tags blurbs (all tentative texts).
- Update `QuizQUestion::PerformanceQuery` for efficiency. **It uses just 1 very efficient query now**.